### PR TITLE
chore: clean hardcoded urls

### DIFF
--- a/libs-private/service-logic/services/authkit-demo/logic/link.api.ts
+++ b/libs-private/service-logic/services/authkit-demo/logic/link.api.ts
@@ -41,7 +41,7 @@ export const createEventLinkTokenApi = async (
 
   const { data: linkData } = matchResultAndHandleHttpError(link, identity);
 
-  const connectionDefinitionUrl = `${process.env.PUBLIC_API_BASE_URL}/v1/public/connection-definitions`;
+  const connectionDefinitionUrl = `${process.env.API_BASE_URL}/v1/public/connection-definitions`;
 
   const connectionDefinitions =
     await makeHttpNetworkCall<ConnectionDefinitions>({

--- a/libs-private/service-logic/services/authkit-demo/logic/link.api.ts
+++ b/libs-private/service-logic/services/authkit-demo/logic/link.api.ts
@@ -41,11 +41,7 @@ export const createEventLinkTokenApi = async (
 
   const { data: linkData } = matchResultAndHandleHttpError(link, identity);
 
-  const connectionDefinitionUrl = url.includes('localhost')
-    ? `${process.env.CONNECTIONS_API_BASE_URL}v1/public/connection-definitions`
-    : url.includes('development')
-      ? 'https://development-api.integrationos.com/v1/public/connection-definitions'
-      : 'https://api.integrationos.com/v1/public/connection-definitions';
+  const connectionDefinitionUrl = `${process.env.PUBLIC_API_BASE_URL}/v1/public/connection-definitions`;
 
   const connectionDefinitions =
     await makeHttpNetworkCall<ConnectionDefinitions>({

--- a/packages/connections/src/apis/link.api.ts
+++ b/packages/connections/src/apis/link.api.ts
@@ -31,7 +31,7 @@ export const createEventLinkTokenApi = async (
       { headers }
     );
 
-    const connectionDefinitionUrl = `${process.env.PUBLIC_API_BASE_URL}/v1/public/connection-definitions`;
+    const connectionDefinitionUrl = `${process.env.API_BASE_URL}/v1/public/connection-definitions`;
 
     const connectionDefinitions = await axios.get<ConnectionDefinitions>(
       `${connectionDefinitionUrl}?limit=100&skip=0`

--- a/packages/connections/src/apis/link.api.ts
+++ b/packages/connections/src/apis/link.api.ts
@@ -31,12 +31,7 @@ export const createEventLinkTokenApi = async (
       { headers }
     );
 
-    const connectionDefinitionUrl = url.includes('localhost')
-      ? `${process.env.CONNECTIONS_API_BASE_URL}v1/public/connection-definitions`
-      : url.includes('development')
-        ? 'https://development-api.integrationos.com/v1/public/connection-definitions'
-        : 'https://api.integrationos.com/v1/public/connection-definitions';
-
+    const connectionDefinitionUrl = `${process.env.PUBLIC_API_BASE_URL}/v1/public/connection-definitions`;
 
     const connectionDefinitions = await axios.get<ConnectionDefinitions>(
       `${connectionDefinitionUrl}?limit=100&skip=0`

--- a/packages/types/generic.ts
+++ b/packages/types/generic.ts
@@ -41,16 +41,5 @@ export interface ClientRecord {
 }
 
 export interface ClientSettings {
-  restrictions: {
-    queues: {
-      development: number;
-      sandbox: number;
-      main: number;
-    };
-    workersPerQueue: {
-      development: number;
-      sandbox: number;
-      main: number;
-    };
-  };
+  restrictions: {};
 }


### PR DESCRIPTION
This PR removes the hardcoded public api urls from the link api. It will require a new environment variable, `PUBLIC_API_BASE_URL`.